### PR TITLE
Add possibility to extend version when calling jwt auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,29 @@ Or install it yourself as:
 
 ## Usage
 
-```
+```ruby
 Fb::Jwt::Auth.configure do |config|
+  # Service token cache domain
+  #
   config.service_token_cache_root_url = ENV['SERVICE_TOKEN_CACHE_ROOT_URL']
 end
+```
 
+### Using other endpoint versions
+
+Service token cache can have different versions of authenticating a service.
+
+You can configure the version:
+
+```ruby
+Fb::Jwt::Auth.configure do |config|
+  config.service_token_cache_auth_version = :v3
+end
+```
+
+### Verifying the token
+
+```ruby
 Fb::Jwt::Auth.new(
   access_token: request.headers['x-access-token-v2'],
   key: 'fb-editor', # service name

--- a/lib/fb/jwt/auth.rb
+++ b/lib/fb/jwt/auth.rb
@@ -6,13 +6,7 @@ require 'active_support/core_ext'
 module Fb
   module Jwt
     class Auth
-      def self.service_token_cache_root_url=(value)
-        @@service_token_cache_root_url = value
-      end
-
-      def self.service_token_cache_root_url
-        @@service_token_cache_root_url
-      end
+      cattr_accessor :service_token_cache_root_url, :service_token_cache_auth_version
 
       def self.configure(&block)
         yield self

--- a/lib/fb/jwt/auth/service_token_client.rb
+++ b/lib/fb/jwt/auth/service_token_client.rb
@@ -5,11 +5,12 @@ require 'base64'
 class Fb::Jwt::Auth::ServiceTokenClient
   class ServiceTokenCacheError < StandardError; end
 
-  attr_accessor :key, :root_url
+  attr_accessor :key, :root_url, :auth_version
 
   def initialize(key)
     @key = key
     @root_url = Fb::Jwt::Auth.service_token_cache_root_url
+    @auth_version = Fb::Jwt::Auth.service_token_cache_auth_version || :v2
   end
 
   def public_key
@@ -32,6 +33,6 @@ class Fb::Jwt::Auth::ServiceTokenClient
   private
 
   def public_key_uri
-    URI.join(@root_url, '/service/v2/', key)
+    URI.join(@root_url, "/service/#{auth_version}/", key)
   end
 end

--- a/spec/fb/jwt/service_token_client_spec.rb
+++ b/spec/fb/jwt/service_token_client_spec.rb
@@ -48,4 +48,29 @@ RSpec.describe Fb::Jwt::Auth::ServiceTokenClient do
       end
     end
   end
+
+  context 'when requesting v3' do
+    before do
+      Fb::Jwt::Auth.configure do |config|
+        config.service_token_cache_auth_version = :v3
+      end
+    end
+
+    after do
+      Fb::Jwt::Auth.configure do |config|
+        config.service_token_cache_auth_version = nil
+      end
+    end
+
+    let(:public_key_uri) { URI('http://localhost:4000/service/v3/some-key') }
+
+    let(:response) do
+      double(code: 200, body: JSON.generate(token: Base64.strict_encode64('R2D2')))
+    end
+
+    it 'should return a base64 decoded public key' do
+      allow(Net::HTTP).to receive(:get_response).with(public_key_uri).and_return(response)
+      expect(service_token_client.public_key).to eq('R2D2')
+    end
+  end
 end


### PR DESCRIPTION
## Context

Just scaping some ideas for discussion around how to solve the other apps and metadata API.

The other apps can use the `:v2` url as default 

Or you can explicitly enforce via config:

```ruby
Fb::Jwt::Auth.configure do |config|
  config.service_token_cache_auth_version = :v2
end
```

For the metadata API we need to come with another endpoint (maybe v3 or whatever we pass on the config):

```ruby
Fb::Jwt::Auth.configure do |config|
  config.service_token_cache_auth_version = :v3
end
```