### PR TITLE
Fix/token not present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .rspec_status
 Gemfile.lock
 .byebug_history
+*.gem

--- a/lib/fb/jwt/auth.rb
+++ b/lib/fb/jwt/auth.rb
@@ -39,7 +39,7 @@ module Fb
       end
 
       def verify!
-        raise TokenNotPresentError.new('Token is not present') if token.nil?
+        raise TokenNotPresentError.new('Token is not present') if token.blank?
 
         application_details = find_application_info
 

--- a/spec/fb/jwt/auth_spec.rb
+++ b/spec/fb/jwt/auth_spec.rb
@@ -95,10 +95,20 @@ RSpec.describe Fb::Jwt::Auth do
 
     context 'when invalid token' do
       context 'when token is not present' do
-        let(:token) { nil }
+        context 'when token is nil' do
+          let(:token) { nil }
 
-        it 'should raise a TokenNotPresentError error' do
-          expect { auth.verify! }.to raise_error(Fb::Jwt::Auth::TokenNotPresentError, 'Token is not present')
+          it 'should raise a TokenNotPresentError error' do
+            expect { auth.verify! }.to raise_error(Fb::Jwt::Auth::TokenNotPresentError, 'Token is not present')
+          end
+        end
+
+        context 'when token is an empty string' do
+          let(:token) { '' }
+
+          it 'should raise a TokenNotPresentError error' do
+            expect { auth.verify! }.to raise_error(Fb::Jwt::Auth::TokenNotPresentError)
+          end
         end
       end
 


### PR DESCRIPTION
Before this PR

If you pass an empty string as a token you get a weird error:

```
Fb::Jwt::Auth.new(token: "", leeway: 60, logger: Rails.logger).verify!
*** JWT::DecodeError Exception: Not enough or too many segments
```

This can cause confusion

After this PR

```
Fb::Jwt::Auth.new(token: "", leeway: 60, logger: Rails.logger).verify!
Fb::Jwt::Auth::TokenNotPresentError (Fb::Jwt::Auth::TokenNotPresentError)
```