### PR TITLE
Retry failed validation with ingore_cache query param

### DIFF
--- a/lib/fb/jwt/auth/service_token_client.rb
+++ b/lib/fb/jwt/auth/service_token_client.rb
@@ -12,9 +12,10 @@ class Fb::Jwt::Auth::ServiceTokenClient
 
   attr_accessor :application, :namespace, :root_url, :api_version
 
-  def initialize(application:, namespace: nil)
+  def initialize(application:, namespace: nil, ignore_cache: false)
     @application = application
     @namespace = namespace
+    @ignore_cache = ignore_cache
     @root_url = Fb::Jwt::Auth.service_token_cache_root_url
     @api_version = Fb::Jwt::Auth.service_token_cache_api_version || :v2
   end
@@ -38,8 +39,14 @@ class Fb::Jwt::Auth::ServiceTokenClient
 
   private
 
+  attr_reader :ignore_cache
+
   def public_key_uri
-    URI.join(root_url, version_url)
+    URI.join(root_url, "#{version_url}#{query_param}")
+  end
+
+  def query_param
+    ignore_cache ? '?ignore_cache=true' : ''
   end
 
   def version_url

--- a/lib/fb/jwt/auth/version.rb
+++ b/lib/fb/jwt/auth/version.rb
@@ -1,7 +1,7 @@
 module Fb
   module Jwt
     class Auth
-      VERSION = "0.2.2"
+      VERSION = "0.3.0"
     end
   end
 end

--- a/spec/fb/jwt/service_token_client_spec.rb
+++ b/spec/fb/jwt/service_token_client_spec.rb
@@ -78,4 +78,35 @@ RSpec.describe Fb::Jwt::Auth::ServiceTokenClient do
       expect(service_token_client.public_key).to eq('R2D2')
     end
   end
+
+  context 'when ignore_cache is required' do
+    let(:service_token_client) do
+      described_class.new(application: 'some-key', namespace: 'some-namespace', ignore_cache: true)
+    end
+    before do
+      Fb::Jwt::Auth.configure do |config|
+        config.service_token_cache_api_version = :v3
+      end
+    end
+    after do
+      Fb::Jwt::Auth.configure do |config|
+        config.service_token_cache_api_version = nil
+      end
+    end
+
+    let(:public_key_uri) do
+      URI('http://localhost:4000/v3/applications/some-key/namespaces/some-namespace?ignore_cache=true')
+    end
+
+    let(:response) do
+      double(code: 200, body: JSON.generate(token: Base64.strict_encode64('R2D2')))
+    end
+
+    it 'should make a request with ignore_cache query param' do
+      allow(Net::HTTP).to receive(:get_response).and_return(response)
+
+      expect(Net::HTTP).to receive(:get_response).with(public_key_uri)
+      service_token_client.public_key
+    end
+  end
 end


### PR DESCRIPTION
If we ever need to rotate any public keys for any services signing JWT tokens we want to do so with zero downtime. The service token cache can receive an ignore_cache parameter which will make it look for a public key in Kubernetes instead of the Redis cache.

Therefore we can rotate a public key in the config maps for any application on the platform or services namespaces and if the first validation fails the gem will make another request which should return the public key in Kubernetes for the requested application.

https://trello.com/c/zz1K8m9d/1039-add-ability-to-rotate-public-keys-in-the-api-without-downtime