### PR TITLE
Feature/generate jwt token

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ Fb::Jwt::Auth.configure do |config|
   config.service_token_cache_root_url = ENV['SERVICE_TOKEN_CACHE_ROOT_URL']
 end
 ```
+In order to generate the service access token we need to use `Fb::Jwt::Auth::ServiceAccessToken.new.generate` or if you require a subject, `Fb::Jwt::Auth::ServiceAccessToken.new(subject: subject).generate`
+
+In the case you need to configure the service access token as a client
+```ruby
+Fb::Jwt::Auth.configure do |config|
+  config.issuer = 'fb-editor'
+  config.namespace = 'formbuilder-saas-test'
+  config.encoded_private_key = 'base64 encoded private key'
+end
+```
 
 ### Using other endpoint versions
 

--- a/lib/fb/jwt/auth.rb
+++ b/lib/fb/jwt/auth.rb
@@ -1,7 +1,7 @@
 require 'fb/jwt/auth/version'
 require 'openssl'
 require 'jwt'
-require 'active_support/core_ext'
+require 'active_support/all'
 
 module Fb
   module Jwt

--- a/lib/fb/jwt/auth.rb
+++ b/lib/fb/jwt/auth.rb
@@ -6,13 +6,18 @@ require 'active_support/all'
 module Fb
   module Jwt
     class Auth
-      cattr_accessor :service_token_cache_root_url, :service_token_cache_api_version
+      cattr_accessor :service_token_cache_root_url,
+                     :service_token_cache_api_version,
+                     :encoded_private_key,
+                     :issuer,
+                     :namespace
 
       def self.configure(&block)
         yield self
       end
 
       autoload :ServiceTokenClient, 'fb/jwt/auth/service_token_client'
+      autoload :ServiceAccessToken, 'fb/jwt/auth/service_access_token'
 
       class TokenNotPresentError < StandardError
       end

--- a/lib/fb/jwt/auth/service_access_token.rb
+++ b/lib/fb/jwt/auth/service_access_token.rb
@@ -1,0 +1,45 @@
+module Fb
+  module Jwt
+    class Auth
+      class ServiceAccessToken
+        attr_reader :encoded_private_key,
+                    :issuer,
+                    :subject,
+                    :namespace
+
+        def initialize(subject: nil)
+          @subject = subject
+          @encoded_private_key = Fb::Jwt::Auth.encoded_private_key
+          @namespace = Fb::Jwt::Auth.namespace
+          @issuer = Fb::Jwt::Auth.issuer
+        end
+
+        def generate
+          return '' if encoded_private_key.blank?
+
+          private_key = OpenSSL::PKey::RSA.new(
+            Base64.strict_decode64(encoded_private_key.chomp)
+          )
+
+          JWT.encode(
+            token,
+            private_key,
+            'RS256'
+          )
+        end
+
+        private
+
+        def token
+          payload = {
+            iss: issuer,
+            iat: Time.current.to_i
+          }
+          payload[:sub] = subject if subject.present?
+          payload[:namespace] = namespace if namespace.present?
+          payload
+        end
+      end
+    end
+  end
+end

--- a/lib/fb/jwt/auth/version.rb
+++ b/lib/fb/jwt/auth/version.rb
@@ -1,7 +1,7 @@
 module Fb
   module Jwt
     class Auth
-      VERSION = "0.3.0"
+      VERSION = "0.4.0"
     end
   end
 end

--- a/spec/fb/jwt/service_access_token_spec.rb
+++ b/spec/fb/jwt/service_access_token_spec.rb
@@ -1,0 +1,94 @@
+RSpec.describe Fb::Jwt::Auth::ServiceAccessToken do
+  let(:private_key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:encoded_private_key) do
+    Base64.strict_encode64(private_key.to_s)
+  end
+  let(:public_key) { private_key.public_key }
+  let(:current_time) { Time.new(2020, 12, 7, 16) }
+
+  describe '#generate' do
+    let(:subject) { nil }
+    let(:namespace) { nil }
+    let(:issuer) { 'fb-editor' }
+    let(:service_token) do
+      described_class.new(
+        subject: subject
+      )
+    end
+
+    before do
+      allow(Fb::Jwt::Auth).to receive(:issuer).and_return(issuer)
+      allow(Fb::Jwt::Auth).to receive(:namespace).and_return(namespace)
+      allow(Fb::Jwt::Auth).to receive(:encoded_private_key).and_return(
+        encoded_private_key
+      )
+      allow(Time).to receive(:current).and_return(current_time)
+    end
+
+    context 'when private key is blank' do
+      let(:encoded_private_key) { {} }
+      let(:subject) { nil }
+
+      it 'returns nil' do
+        expect(service_token.generate).to eq('')
+      end
+    end
+
+    context 'when there is a subject' do
+      let(:subject) { 'user-id-123' }
+
+      it 'generates jwt access token with a sub' do
+        expect(
+          JWT.decode(service_token.generate, public_key, true, { algorithm: 'RS256' })
+        ).to eq([
+          {
+            'iat' => current_time.to_i,
+            'iss' => 'fb-editor',
+            'sub' => 'user-id-123'
+          },
+          {
+            'alg' => 'RS256'
+          }
+        ])
+      end
+    end
+
+    context 'when there is no subject ' do
+      let(:subject) { nil }
+
+      it 'generate jwt access token without a sub' do
+        expect(
+          JWT.decode(service_token.generate, public_key, true, { algorithm: 'RS256' })
+        ).to eq([
+          {
+            'iat' => current_time.to_i,
+            'iss' => 'fb-editor'
+          },
+          {
+            'alg' => 'RS256'
+          }
+        ])
+      end
+    end
+
+    context 'when there is a namespace' do
+      let(:subject) { nil }
+      let(:namespace) { 'formbuilder-saas-test' }
+
+      it 'generate jwt access token without a sub' do
+        expect(
+          JWT.decode(service_token.generate, public_key, true, { algorithm: 'RS256' })
+        ).to eq([
+          {
+            'iat' => current_time.to_i,
+            'iss' => 'fb-editor',
+            'namespace' => 'formbuilder-saas-test'
+          },
+          {
+            'alg' => 'RS256'
+          }
+        ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

The logic of generating the access token is kinda duplicated in the editor and the runner (or future apps we will create). In order to avoid duplication, we decided to move the logic to the gem.

You can see their usage on the editor and runner branch:

1. Editor usage: https://github.com/ministryofjustice/fb-editor/pull/43
2. Runner usage: In progress -> https://github.com/ministryofjustice/fb-runner/compare/jwt-auth-service-access-token-generation?expand=1