### PR TITLE
Do not base64 decode private key

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 0.5.0
+* Do not base64 decode private key
+
+# 0.4.0
+* Generate the access token
+
 # 0.3.0
 * Request non cached version of public key if first validition fails
 

--- a/lib/fb/jwt/auth/service_access_token.rb
+++ b/lib/fb/jwt/auth/service_access_token.rb
@@ -17,9 +17,7 @@ module Fb
         def generate
           return '' if encoded_private_key.blank?
 
-          private_key = OpenSSL::PKey::RSA.new(
-            Base64.strict_decode64(encoded_private_key.chomp)
-          )
+          private_key = OpenSSL::PKey::RSA.new(encoded_private_key.chomp)
 
           JWT.encode(
             token,

--- a/lib/fb/jwt/auth/version.rb
+++ b/lib/fb/jwt/auth/version.rb
@@ -1,7 +1,7 @@
 module Fb
   module Jwt
     class Auth
-      VERSION = "0.4.0"
+      VERSION = "0.5.0"
     end
   end
 end

--- a/spec/fb/jwt/service_access_token_spec.rb
+++ b/spec/fb/jwt/service_access_token_spec.rb
@@ -1,8 +1,6 @@
 RSpec.describe Fb::Jwt::Auth::ServiceAccessToken do
   let(:private_key) { OpenSSL::PKey::RSA.generate(2048) }
-  let(:encoded_private_key) do
-    Base64.strict_encode64(private_key.to_s)
-  end
+  let(:encoded_private_key) { private_key.to_pem }
   let(:public_key) { private_key.public_key }
   let(:current_time) { Time.new(2020, 12, 7, 16) }
 


### PR DESCRIPTION
The private key is base64 encoded when it is added to the kubernetes config. However kubernetes itself base64 decodes it before adding it to the environment of the container. Therefore there is no need to base64 decode it here.