### PR TITLE
Supply issuer to service token client

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+# 0.6.0
+* Supplier issuer to service token client
+
 # 0.5.0
 * Do not base64 decode private key
 

--- a/lib/fb/jwt/auth/service_access_token.rb
+++ b/lib/fb/jwt/auth/service_access_token.rb
@@ -7,11 +7,11 @@ module Fb
                     :subject,
                     :namespace
 
-        def initialize(subject: nil)
+        def initialize(subject: nil, issuer: nil)
           @subject = subject
           @encoded_private_key = Fb::Jwt::Auth.encoded_private_key
           @namespace = Fb::Jwt::Auth.namespace
-          @issuer = Fb::Jwt::Auth.issuer
+          @issuer = issuer || Fb::Jwt::Auth.issuer
         end
 
         def generate

--- a/lib/fb/jwt/auth/version.rb
+++ b/lib/fb/jwt/auth/version.rb
@@ -1,7 +1,7 @@
 module Fb
   module Jwt
     class Auth
-      VERSION = "0.5.0"
+      VERSION = "0.6.0"
     end
   end
 end

--- a/spec/fb/jwt/service_access_token_spec.rb
+++ b/spec/fb/jwt/service_access_token_spec.rb
@@ -7,15 +7,17 @@ RSpec.describe Fb::Jwt::Auth::ServiceAccessToken do
   describe '#generate' do
     let(:subject) { nil }
     let(:namespace) { nil }
-    let(:issuer) { 'fb-editor' }
+    let(:issuer) { nil }
+    let(:default_issuer) { 'fb-editor' }
     let(:service_token) do
       described_class.new(
-        subject: subject
+        subject: subject,
+        issuer: issuer
       )
     end
 
     before do
-      allow(Fb::Jwt::Auth).to receive(:issuer).and_return(issuer)
+      allow(Fb::Jwt::Auth).to receive(:issuer).and_return(default_issuer)
       allow(Fb::Jwt::Auth).to receive(:namespace).and_return(namespace)
       allow(Fb::Jwt::Auth).to receive(:encoded_private_key).and_return(
         encoded_private_key
@@ -81,6 +83,24 @@ RSpec.describe Fb::Jwt::Auth::ServiceAccessToken do
             'iat' => current_time.to_i,
             'iss' => 'fb-editor',
             'namespace' => 'formbuilder-saas-test'
+          },
+          {
+            'alg' => 'RS256'
+          }
+        ])
+      end
+    end
+
+    context 'when an issuer is passed in' do
+      let(:issuer) { 'some-awesome-form' }
+
+      it 'generates a jwt access token with the supplied issuer' do
+        expect(
+          JWT.decode(service_token.generate, public_key, true, { algorithm: 'RS256' })
+        ).to eq([
+          {
+            'iat' => current_time.to_i,
+            'iss' => issuer
           },
           {
             'alg' => 'RS256'


### PR DESCRIPTION
The issuer plays a pivotal role in the JWT authentication mechanism. It is used when the service token cache makes a call to either the redis key that holds the public key or more importantly when it attempts to retreive the public key from kubernetes.

It is actually searching for a config map which contains that public key. The name of that config map takes the form
`fb-<parameterised-service-name>-config-map` where the parametersed-service-name can be whatever the service owner calls their form. e.g my-amazing-form, apply-financial-deputy, leavers etc.

The actual name of this parameter changes depending on which app you are in on the platform. Here it is known as issuer and is set as the value to the `iss` property in the JWT.

The Editor uses a parameterised version of the service name in order to create the config map that contains the public key for a given service when it publishes said service. However it calls this creation the  `service_slug`.

See:

https://github.com/ministryofjustice/fb-editor/blob/201e91e249d6a61caee60a2ef0eecf7cf626b5fd/app/services/publisher/service_provisioner.rb#L28

and

https://github.com/ministryofjustice/fb-editor/blob/201e91e249d6a61caee60a2ef0eecf7cf626b5fd/app/services/publisher/service_provisioner.rb#L47

The v3 route for the service token cache then expects a path parameter which is that service slug, but it calls the parameter `application`.

Internally the service token cache then passes the `application` as a `service_slug` parameter on the PublicKeyService class before finally being converted for the very last time into what the Kubernetes Adapter thinks of as a `secret_name`. Except it's actually not a secret name at all, it's the name of the config map that the Editor created waaaaaaay back in this commit message.

The important thing to remember is the name of your service is what you need to pass into the ServiceTokenClient. E.g `apply-financial-deputy`. Eventually what actually ends up getting requested in Cloud Platform is `fb-apply-financial-deputy-config-map`. The runner for a given service is the thing that will have to inject the issuer when generating the JWT therefore it will need to know its' own service slug from either the metadata or from an injected environment variable at publishing time.

Amazing.